### PR TITLE
Various fixes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,13 @@ ifeq ($(WITH_DYNAMIC_LIBS),1)
 TESTS_EXEC += $(BUILD_DIR)/ec_self_tests_dyn $(BUILD_DIR)/ec_utils_dyn
 endif
 
+EXEC_TO_CLEAN = $(BUILD_DIR)/ec_self_tests $(BUILD_DIR)/ec_utils $(BUILD_DIR)/ec_self_tests_dyn $(BUILD_DIR)/ec_utils_dyn
+
 # all and clean, as you might expect
 all: depend $(LIBS) $(TESTS_EXEC)
 
 clean:
-	@rm -f $(LIBS) $(TESTS_EXEC)
+	@rm -f $(LIBS) $(EXEC_TO_CLEAN)
 	@find -name '*.o' -exec rm -f '{}' \;
 	@find -name '*.d' -exec rm -f '{}' \;
 	@find -name '*.a' -exec rm -f '{}' \;

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ $(LIBARITH): $(LIBARITH_OBJECTS)
 # Compile dynamic libraries if the user asked to
 ifeq ($(WITH_DYNAMIC_LIBS),1)
 $(LIBARITH_DYN): $(LIBARITH_OBJECTS)
-	$(CC) $(LIB_DYN_CFLAGS) $^ -o $@
+	$(CC) $(LIB_CFLAGS) $(LIB_DYN_LDFLAGS) $^ -o $@
 endif
 
 # curve module
@@ -133,7 +133,7 @@ $(LIBEC): $(LIBEC_OBJECTS)
 # Compile dynamic libraries if the user asked to
 ifeq ($(WITH_DYNAMIC_LIBS),1)
 $(LIBEC_DYN): $(LIBEC_OBJECTS)
-	$(CC) $(LIB_DYN_CFLAGS) $^ -o $@
+	$(CC) $(LIB_CFLAGS) $(LIB_DYN_LDFLAGS) $^ -o $@
 endif
 
 # Hash module
@@ -181,7 +181,7 @@ $(LIBSIGN): $(LIBSIGN_OBJECTS)
 # Compile dynamic libraries if the user asked to
 ifeq ($(WITH_DYNAMIC_LIBS),1)
 $(LIBSIGN_DYN): $(LIBSIGN_OBJECTS)
-	$(CC) $(LIB_DYN_CFLAGS) $^ -o $@
+	$(CC) $(LIB_CFLAGS) $(LIB_DYN_LDFLAGS) $^ -o $@
 endif
 
 # Test elements (objects and binaries)

--- a/common.mk
+++ b/common.mk
@@ -116,3 +116,13 @@ endif
 LIBARITH = $(BUILD_DIR)/libarith.a
 LIBEC = $(BUILD_DIR)/libec.a
 LIBSIGN = $(BUILD_DIR)/libsign.a
+
+# Compile dynamic libraries if the user asked to
+ifeq ($(WITH_DYNAMIC_LIBS),1)
+# Dynamic libraries to produce or link to
+LIBARITH_DYN = $(BUILD_DIR)/libarith.so
+LIBEC_DYN = $(BUILD_DIR)/libec.so
+LIBSIGN_DYN = $(BUILD_DIR)/libsign.so
+# The flag to generate shared librarie
+LIB_DYN_CFLAGS ?= -shared -Wl,-z,relro,-z,now
+endif

--- a/common.mk
+++ b/common.mk
@@ -109,7 +109,7 @@ endif
 ifndef USER_DEFINED_LDFLAGS
 BIN_LDFLAGS ?= $(LDFLAGS) $(FPIE_LDFLAGS)
 else
-BIN_LDFLAGS ?= $(LDFLAGS)
+BIN_LDFLAGS ?= $(USER_DEFINED_LDFLAGS)
 endif
 
 # Static libraries to produce or link to

--- a/common.mk
+++ b/common.mk
@@ -123,6 +123,6 @@ ifeq ($(WITH_DYNAMIC_LIBS),1)
 LIBARITH_DYN = $(BUILD_DIR)/libarith.so
 LIBEC_DYN = $(BUILD_DIR)/libec.so
 LIBSIGN_DYN = $(BUILD_DIR)/libsign.so
-# The flag to generate shared librarie
-LIB_DYN_CFLAGS ?= -shared -Wl,-z,relro,-z,now
+# The ld flags to generate shared librarie
+LIB_DYN_LDFLAGS ?= -shared -Wl,-z,relro,-z,now
 endif

--- a/src/examples/Makefile
+++ b/src/examples/Makefile
@@ -6,6 +6,10 @@ include $(ROOT_DIR)/common.mk
 CFLAGS += -I$(ROOT_DIR)/src/ -I$(ROOT_DIR)/src/external_deps
 
 all:	nn_example fp_example curve_basic_examples curve_ecdh
+ifeq ($(WITH_DYNAMIC_LIBS),1)
+# If the user asked for dynamic libraries, compile versions of our binaries against them
+all:	nn_example_dyn fp_example_dyn curve_basic_examples_dyn curve_ecdh_dyn
+endif
 
 nn_example:
 	$(CC) $(BIN_CFLAGS) -DNN_EXAMPLE nn_miller_rabin.c nn_pollard_rho.c $(ROOT_DIR)/src/external_deps/print.c $(ROOT_DIR)/src/external_deps/rand.c $(LIBARITH) $(BIN_LDFLAGS) -o nn_pollard_rho
@@ -18,7 +22,24 @@ curve_basic_examples:
 curve_ecdh:
 	$(CC) $(BIN_CFLAGS) -DCURVE_ECDH curve_ecdh.c $(ROOT_DIR)/src/external_deps/print.c $(ROOT_DIR)/src/external_deps/rand.c $(BIN_LDFLAGS) $(LIBEC) -o curve_ecdh
 
+
+# If the user asked for dynamic libraries, compile versions of our binaries against them
+ifeq ($(WITH_DYNAMIC_LIBS),1)
+nn_example_dyn:
+	$(CC) $(BIN_CFLAGS) -DNN_EXAMPLE nn_miller_rabin.c nn_pollard_rho.c $(ROOT_DIR)/src/external_deps/print.c $(ROOT_DIR)/src/external_deps/rand.c $(BIN_LDFLAGS) -L$(BUILD_DIR) -larith -o nn_pollard_rho_dyn
+
+fp_example_dyn:
+	$(CC) $(BIN_CFLAGS) -DFP_EXAMPLE nn_miller_rabin.c fp_square_residue.c $(ROOT_DIR)/src/external_deps/print.c $(ROOT_DIR)/src/external_deps/rand.c $(BIN_LDFLAGS) -L$(BUILD_DIR) -larith -o fp_square_residue_dyn
+
+curve_basic_examples_dyn:
+	$(CC) $(BIN_CFLAGS) -DCURVE_BASIC_EXAMPLES fp_square_residue.c curve_basic_examples.c $(ROOT_DIR)/src/external_deps/print.c $(ROOT_DIR)/src/external_deps/rand.c $(ROOT_DIR)/src/external_deps/time.c  $(BIN_LDFLAGS) -L$(BUILD_DIR) -lec -o curve_basic_examples_dyn
+curve_ecdh_dyn:
+	$(CC) $(BIN_CFLAGS) -DCURVE_ECDH curve_ecdh.c $(ROOT_DIR)/src/external_deps/print.c $(ROOT_DIR)/src/external_deps/rand.c $(BIN_LDFLAGS) -L$(BUILD_DIR) -lec -o curve_ecdh_dyn
+endif
+
+
 clean:
 	@rm -f nn_pollard_rho fp_square_residue curve_basic_examples curve_ecdh
+	@rm -f nn_pollard_rho_dyn fp_square_residue_dyn curve_basic_examples_dyn curve_ecdh_dyn
 
 .PHONY: all clean 16 32 64 debug debug16 debug32 debug64 force_arch32 force_arch64


### PR DESCRIPTION
Add improvements/fixes to libecc compilation, mainly:

- Add the ability to compile dynamic libraries in addition to static libraries by exporting the WITH_DYNAMIC_LIBS=1 environment variable.
- Add cleaning targets.
- Small fixes.