### PR TITLE
Prevent MAX and MIN macros conflicting with existing macros

### DIFF
--- a/src/arithmetic_tests/arithmetic_tests.c
+++ b/src/arithmetic_tests/arithmetic_tests.c
@@ -483,7 +483,7 @@ int test_##test_name(const char ATTRIBUTE_UNUSED *op, void **params, int test_nu
 	MUST_HAVE(memcmp(operation, op, sizeof(operation)) == 0);\
 	\
 	/* Sanity check: check that the parameters passed from the file are the same as the ones declared in the test */\
-	if(memcmp(global_parameters, parameters_types, MIN(MAX_PARAMS, strlen(parameters_types))) != 0){\
+	if(memcmp(global_parameters, parameters_types, LOCAL_MIN(MAX_PARAMS, strlen(parameters_types))) != 0){\
 		printf("Error: parameters %s given in the test file differ from the test expected parameters (%s)\n", parameters_types, global_parameters);\
 		return -1;\
 	}\
@@ -1078,7 +1078,7 @@ int main(int argc, char *argv[])
 			rec = t + 1;
 		}
 		/* Save current parameters format in the global variable */
-		memcpy(global_parameters, s, MIN(nrecs, MAX_PARAMS));
+		memcpy(global_parameters, s, LOCAL_MIN(nrecs, MAX_PARAMS));
 		curr_test_fun = NULL;
 		FIND_FUN_IN_DISPATCH_TABLE(op, curr_test_fun);
 		if (curr_test_fun == NULL) {

--- a/src/nn/nn_add.c
+++ b/src/nn/nn_add.c
@@ -66,7 +66,7 @@ static word_t _nn_cnd_add(int cnd, nn_t out, nn_src_t in1, nn_src_t in2)
 	nn_check_initialized(in2);
 
 	/* Handle aliasing */
-	loop_wlen = MAX(in1->wlen, in2->wlen);
+	loop_wlen = LOCAL_MAX(in1->wlen, in2->wlen);
 	if ((out != in1) && (out != in2)) {
 		nn_init(out, loop_wlen * WORD_BYTES);
 	} else {
@@ -233,7 +233,7 @@ void nn_cnd_sub(int cnd, nn_t out, nn_src_t in1, nn_src_t in2)
 	nn_check_initialized(in2);
 
 	/* Handle aliasing */
-	loop_wlen = MAX(in1->wlen, in2->wlen);
+	loop_wlen = LOCAL_MAX(in1->wlen, in2->wlen);
 	if ((out != in1) && (out != in2)) {
 		nn_init(out, loop_wlen * WORD_BYTES);
 	} else {

--- a/src/nn/nn_logical.c
+++ b/src/nn/nn_logical.c
@@ -93,7 +93,7 @@ void nn_lshift(nn_t out, nn_src_t in, bitcnt_t cnt)
 	}
 
 	/* Adapt output length accordingly */
-	owlen = (u8)MIN(BIT_LEN_WORDS(cnt + nn_bitlen(in)),
+	owlen = (u8)LOCAL_MIN(BIT_LEN_WORDS(cnt + nn_bitlen(in)),
 			BIT_LEN_WORDS(NN_MAX_BIT_LEN));
 	out->wlen = owlen;
 

--- a/src/sig/eckcdsa.c
+++ b/src/sig/eckcdsa.c
@@ -159,7 +159,7 @@ static void buf_lshift(u8 *buf, u8 buflen, u8 shift)
 
 int _eckcdsa_sign_init(struct ec_sign_context *ctx)
 {
-	u8 tmp_buf[MAX(2 * BYTECEIL(CURVES_MAX_P_BIT_LEN), MAX_BLOCK_SIZE)];
+	u8 tmp_buf[LOCAL_MAX(2 * BYTECEIL(CURVES_MAX_P_BIT_LEN), MAX_BLOCK_SIZE)];
 	const ec_pub_key *pub_key;
 	aff_pt y_aff;
 	u8 p_len;
@@ -511,7 +511,7 @@ int _eckcdsa_sign_finalize(struct ec_sign_context *ctx, u8 *sig, u8 siglen)
 int _eckcdsa_verify_init(struct ec_verify_context *ctx,
 			 const u8 *sig, u8 siglen)
 {
-	u8 tmp_buf[MAX(2 * BYTECEIL(CURVES_MAX_P_BIT_LEN), MAX_BLOCK_SIZE)];
+	u8 tmp_buf[LOCAL_MAX(2 * BYTECEIL(CURVES_MAX_P_BIT_LEN), MAX_BLOCK_SIZE)];
 	u8 p_len, r_len, s_len, z_len;
 	bitcnt_t q_bit_len;
 	const ec_pub_key *pub_key;

--- a/src/sig/eckcdsa.h
+++ b/src/sig/eckcdsa.h
@@ -25,7 +25,7 @@
 #include "../hash/hash_algs.h"
 #include "../curves/curves.h"
 
-#define ECKCDSA_R_LEN(hsize, q_bit_len) MIN(hsize, BYTECEIL(q_bit_len))
+#define ECKCDSA_R_LEN(hsize, q_bit_len) LOCAL_MIN(hsize, BYTECEIL(q_bit_len))
 #define ECKCDSA_S_LEN(q_bit_len) (BYTECEIL(q_bit_len))
 #define ECKCDSA_SIGLEN(hsize, q_bit_len) (ECKCDSA_R_LEN(hsize, q_bit_len) + \
 					  ECKCDSA_S_LEN(q_bit_len))

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -75,12 +75,8 @@
 #endif
 #endif /* AFL_FUZZ or FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION */
 
-#ifndef MAX
-#define MAX(x, y) (((x) > (y)) ? (x) : (y))
-#endif
-#ifndef MIN
-#define MIN(x, y) (((x) < (y)) ? (x) : (y))
-#endif
+#define LOCAL_MAX(x, y) (((x) > (y)) ? (x) : (y))
+#define LOCAL_MIN(x, y) (((x) < (y)) ? (x) : (y))
 
 #define BYTECEIL(numbits) (((numbits) + 7) / 8)
 

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -75,8 +75,12 @@
 #endif
 #endif /* AFL_FUZZ or FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION */
 
+#ifndef MAX
 #define MAX(x, y) (((x) > (y)) ? (x) : (y))
+#endif
+#ifndef MIN
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))
+#endif
 
 #define BYTECEIL(numbits) (((numbits) + 7) / 8)
 


### PR DESCRIPTION
MAX and MIN are often defined by the platform or other external code. Only define them if they aren't already defined.