### PR TITLE
Missing include in rand.c on Windows

### DIFF
--- a/src/external_deps/rand.c
+++ b/src/external_deps/rand.c
@@ -67,6 +67,7 @@ int get_random(unsigned char *buf, u16 len)
 /* Windows case */
 #elif defined(WITH_STDLIB) && defined(__WIN32__)
 #include <windows.h>
+#include <wincrypt.h>
 
 int get_random(unsigned char *buf, u16 len)
 {


### PR DESCRIPTION
The type `HCRYPTOPROV` is not found on Windows 10 for me unless wincrypt.h is included.