### PR TITLE
Memset fix, found by valgrind

### DIFF
--- a/src/sig/ecdsa.c
+++ b/src/sig/ecdsa.c
@@ -537,6 +537,9 @@ int _ecdsa_verify_finalize(struct ec_verify_context *ctx)
 	u8 hsize;
 	int ret;
 
+	local_memset(&uG, 0, sizeof(prj_pt));
+	local_memset(&vY, 0, sizeof(prj_pt));
+
 	/*
 	 * First, verify context has been initialized and public
 	 * part too. This guarantees the context is an ECDSA


### PR DESCRIPTION
==1592090==
==1592090== HEAP SUMMARY:
==1592090==     in use at exit: 0 bytes in 0 blocks
==1592090==   total heap usage: 11 allocs, 11 frees, 23,864 bytes allocated
==1592090==
==1592090== All heap blocks were freed -- no leaks are possible
==1592090==
==1592090== Use --track-origins=yes to see where uninitialised values come from
==1592090== ERROR SUMMARY: 2 errors from 1 contexts (suppressed: 0 from 0)
==1592090==
==1592090== 2 errors in context 1 of 1:
==1592090== Conditional jump or move depends on uninitialised value(s)
==1592090==    at 0x10FBBF: prj_pt_copy (prj_pt.c:138)
==1592090==    by 0x1116B8: _prj_pt_mul_ltr_monty_ladder (prj_pt_monty.c:721)
==1592090==    by 0x111832: _prj_pt_mul_ltr_monty (prj_pt_monty.c:743)
==1592090==    by 0x111832: prj_pt_mul_ltr_monty (prj_pt_monty.c:765)
==1592090==    by 0x111889: prj_pt_mul_monty (prj_pt_monty.c:773)
==1592090==    by 0x112E45: _ecdsa_verify_finalize (ecdsa.c:615)
==1592090==    by 0x113D5A: ec_verify_finalize (sig_algs.c:516)
==1592090==    by 0x10CBE0: verify_bin_file (ec_utils.c:1007)
==1592090==    by 0x10D4D0: main (ec_utils.c:1327)
==1592090==
==1592090== ERROR SUMMARY: 2 errors from 1 contexts (suppressed: 0 from 0)