### PR TITLE
Workaround for windows on file rename for expand_libecc.py

### DIFF
--- a/scripts/expand_libecc.py
+++ b/scripts/expand_libecc.py
@@ -1292,7 +1292,10 @@ def file_remove_pattern(fname, pat):
             if not re.search(pat, line):
                 out.write(line)
         out.close()
-        os.rename(out_fname, fname)
+    
+    if os.path.exists(fname):
+        os.remove(fname)
+    os.rename(out_fname, fname)
 
 def remove_file(fname):
     # Remove file

--- a/scripts/expand_libecc.py
+++ b/scripts/expand_libecc.py
@@ -1294,7 +1294,7 @@ def file_remove_pattern(fname, pat):
         out.close()
     
     if os.path.exists(fname):
-        os.remove(fname)
+        remove_file(fname)
     os.rename(out_fname, fname)
 
 def remove_file(fname):


### PR DESCRIPTION
As the documentation for `os.rename` ( https://docs.python.org/3/library/os.html#os.rename ) says, "On Windows, if dst exists a FileExistsError is always raised."
Renaming the "curves_list.h.tmp" to "curves_list.h" on the fly fails on windows.

This modification allows the script to work properly on windows.

tested on windows 10 with python 3.9.0 and on linux (WSL) with python 3.8.2