### PR TITLE
Add options to use blank external dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,7 +693,8 @@ compiler is not gcc/clang compatible, the user can modify the CFLAGS as well as 
 for 8-bit MCUs to 64-bit CPUs. If the toolchain does not have a [`stdint.h`](http://pubs.opengroup.org/onlinepubs/009695399/basedefs/stdint.h.html)
 header, it is still possible to compile libecc by exporting LIBECC_NOSTDLIB=1: in this case, the code will try to
 guess and fit to native C types or throw an error so that the user can adapt [src/words/types.h](src/words/types.h) to its specific case.
-* The library core is platform independent. However, when the platform is not recognized (i.e. everything aside UNIX/Windows/Mac OS),
+* The library core is platform independent. However, when the platform is not recognized (i.e. everything aside UNIX/Windows/Mac OS)
+and when not compiled with `WITH_BLANK_EXTERNAL_DEPENDENCIES` specified,
 an error is thrown at compilation time asking the user to provide implementations for **external dependencies**
 in [src/external&lowbar;deps/](src/external_deps), namely:
   * The printing helper in [src/external&lowbar;deps/print.c](src/external_deps/print.c). This helper serves output debugging purposes.
@@ -702,6 +703,11 @@ in [src/external&lowbar;deps/](src/external_deps), namely:
   * The random helper in [src/external&lowbar;deps/rand.c](src/external_deps/rand.c). This helper is used in the core library for the signature
   schemes. One should notice that a **good random source** is **crucial** for the security of Elliptic Curve based signature schemes,
   so great care must be taken when implementing this.
+
+If `WITH_BLANK_EXTERNAL_DEPENDENCIES` is specified in compiling time, blank implementation for these helpers are provided.
+As using many algorithms with no reliable CSRNGs can be quite dangerous, with `WITH_BLANK_EXTERNAL_DEPENDENCIES` `get_random`
+will just return error, you should not using algorithms depending on random number generation. They are provided
+because it is useful in some restricted environments or in some specific applications (e.g. deterministic signature generation).
 
 Some other external dependencies could arise depending on the compilation chain and/or the platform. Such an example is the
 implementation of the gcc and clang stack protection option, usually expecting the user to provide stack canaries generation
@@ -890,7 +896,8 @@ other compilers (`-c` flag to generate object files, `-o` flag to define output 
 [partially implemented](http://sdcc.sourceforge.net/mediawiki/index.php/Standard_compliance).
 * The compiler has "exotic" targets such as the Zilog Z80 MCU.
 
-We suppose that the user has also provided the **external dependencies** for print, random and time
+Unless compiling with `WITH_BLANK_EXTERNAL_DEPENDENCIES` specified,
+we suppose that the user has also provided the **external dependencies** for print, random and time
 functions (otherwise explicit errors will be thrown by #error directives).
 
 We will show how overloading the Makefile flags can be of use in this case. Say that we want

--- a/common.mk
+++ b/common.mk
@@ -123,6 +123,11 @@ ifneq ($(LIBECC_NOSTDLIB),1)
 CFLAGS += -DWITH_STDLIB
 endif
 
+# By default, we don't use blank external dependencies
+ifneq ($(LIBECC_BLANK_EXTERNAL_DEPENDENCIES),1)
+CFLAGS += -DWITH_BLANK_EXTERNAL_DEPENDENCIES
+endif
+
 # Let's now define the two kinds of CFLAGS we will use for building our
 # library (LIB_CFLAGS) and binaries (BIN_CFLAGS) objects.
 # If the user has not overriden the CFLAGS, we add the usual gcc/clang

--- a/src/external_deps/print.c
+++ b/src/external_deps/print.c
@@ -26,6 +26,12 @@ void ext_printf(const char *format, ...)
 	vprintf(format, arglist);
 	va_end(arglist);
 }
+
+#elif defined(WITH_BLANK_EXTERNAL_DEPENDENCIES)
+void ext_printf(const char *format, ...) {
+	FORCE_USED_VAR(format);
+}
+
 #else
 #error "print.c: you have to implement ext_printf"
 #endif

--- a/src/external_deps/rand.c
+++ b/src/external_deps/rand.c
@@ -106,6 +106,11 @@ err:
 	return ret;
 }
 
+#elif defined(WITH_BLANK_EXTERNAL_DEPENDENCIES)
+int get_random(unsigned char *buf, u16 len) {
+  return -1;
+}
+
 /* No platform detected, the user must provide an implementation! */
 #else
 /* WARNING: when providing/implementing the get_random function, one must:

--- a/src/external_deps/time.c
+++ b/src/external_deps/time.c
@@ -66,6 +66,14 @@ err:
 	return ret;
 }
 
+#elif defined(WITH_BLANK_EXTERNAL_DEPENDENCIES)
+int get_ms_time(u64 *time) {
+  static u64 current_time = 0;
+  *time = current_time;
+  current_time++;
+  return 0;
+}
+
 /* No platform detected, the used must provide an implementation! */
 #else
 #error "time.c: you have to implement get_ms_time()"


### PR DESCRIPTION
This commit makes external dependencies unnecessary when `WITH_BLANK_EXTERNAL_DEPENDENCIES` is specified.
It is useful in some restricted environment or in some specific applications (e.g. deterministic signature generation).

I think it is something nice to have.