### PR TITLE
Makefile refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,11 @@ $(OBJ_DIR)/%.o: %.c
 $(shell mkdir -p $(dir $(OBJS)) >/dev/null)
 $(shell mkdir -p $(BUILD_DIR) >/dev/null)
 
+# Make a note of the MAKEFILE_LIST at this stage of parsing the Makefile
+# It is important here to use the ':=' operator so it is evaluated only once,
+# and to do this before all the DEPS files are included as makefiles.
+MAKEFILES:=$(MAKEFILE_LIST)
+
 # Make object files depend on all makefiles used - this forces a rebuild if any
 # of the makefiles are changed
 $(OBJS) : $(MAKEFILES)

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 
 # Where to put generated objects
 BUILD_DIR ?= build
+# Default to the previous behaviour and keep generated .o & .d files next to the source code
+OBJ_DIR ?=.
 include common.mk
 
 
@@ -23,218 +25,143 @@ endif
 EXEC_TO_CLEAN = $(BUILD_DIR)/ec_self_tests $(BUILD_DIR)/ec_utils $(BUILD_DIR)/ec_self_tests_dyn $(BUILD_DIR)/ec_utils_dyn
 
 # all and clean, as you might expect
-all: depend $(LIBS) $(TESTS_EXEC)
+all: $(LIBS) $(TESTS_EXEC)
 
 clean:
 	@rm -f $(LIBS) $(EXEC_TO_CLEAN)
-	@find . -name '*.o' -exec rm -f '{}' \;
-	@find . -name '*.d' -exec rm -f '{}' \;
-	@find . -name '*.a' -exec rm -f '{}' \;
-	@find . -name '*.so' -exec rm -f '{}' \;
+	@find $(OBJ_DIR)/ -name '*.o' -exec rm -f '{}' \;
+	@find $(OBJ_DIR)/ -name '*.d' -exec rm -f '{}' \;
+	@find $(BUILD_DIR)/ -name '*.a' -exec rm -f '{}' \;
+	@find $(BUILD_DIR)/ -name '*.so' -exec rm -f '{}' \;
 	@find . -name '*~'  -exec rm -f '{}' \;
 
-# library configuration files
 
-CFG_DEPS = $(wildcard src/*.h)
+
+# --- Source Code ---
 
 # external dependencies
-
 EXT_DEPS_SRC = $(wildcard src/external_deps/*.c)
-EXT_DEPS_OBJECTS = $(patsubst %.c, %.o, $(EXT_DEPS_SRC))
-EXT_DEPS_DEPS = $(patsubst %.c, %.d, $(EXT_DEPS_SRC))
-
-src/external_deps/%.d: src/external_deps/%.c
-	$(CC) $(LIB_CFLAGS) -MM $< -MF $@
-
-src/external_deps/%.o: src/external_deps/%.c
-	$(CC) $(LIB_CFLAGS) -c $< -o $@
 
 # utils module (for the ARITH layer, we only need
 # NN and FP - and not curves - related stuff. Same goes
 # for EC and SIGN. Hence the distinction between three
 # sets of utils objects.
-
 UTILS_ARITH_SRC = src/utils/utils.c
 UTILS_ARITH_SRC += $(wildcard src/utils/*_nn.c)
 UTILS_ARITH_SRC += $(wildcard src/utils/*_fp.c)
 UTILS_ARITH_SRC += $(wildcard src/utils/*_buf.c)
-UTILS_ARITH_OBJECTS = $(patsubst %.c, %.o, $(UTILS_ARITH_SRC))
-UTILS_ARITH_DEPS = $(patsubst %.c, %.d, $(UTILS_ARITH_SRC))
-
 UTILS_EC_SRC = $(wildcard src/utils/*_curves.c)
-UTILS_EC_OBJECTS = $(patsubst %.c, %.o, $(UTILS_EC_SRC))
-UTILS_EC_DEPS = $(patsubst %.c, %.d, $(UTILS_EC_SRC))
-
 UTILS_SIGN_SRC = $(wildcard src/utils/*_keys.c)
-UTILS_SIGN_OBJECTS = $(patsubst %.c, %.o, $(UTILS_SIGN_SRC))
-UTILS_SIGN_DEPS = $(patsubst %.c, %.d, $(UTILS_SIGN_SRC))
-
-src/utils/%.d: src/utils/%.c
-	$(CC) $(LIB_CFLAGS) -MM $< -MF $@
-
-src/utils/%.o: src/utils/%.c
-	$(CC) $(LIB_CFLAGS) -c $< -o $@
-
 
 # nn module
-
-NN_CONFIG = src/nn/nn_config.h
 NN_SRC = $(wildcard src/nn/n*.c)
-NN_OBJECTS = $(patsubst %.c, %.o, $(NN_SRC))
-NN_DEPS = $(patsubst %.c, %.d, $(NN_SRC))
-
-src/nn/%.d: src/nn/%.c $(NN_CONFIG) $(CFG_DEPS)
-	$(if $(filter $(wildcard src/nn/*.c), $<), @$(CC) $(LIB_CFLAGS) -MM $< -MF $@)
-
-src/nn/%.o: src/nn/%.c $(NN_CONFIG) $(CFG_DEPS)
-	$(if $(filter $(wildcard src/nn/*.c), $<), $(CC) $(LIB_CFLAGS) -c $< -o $@)
 
 # fp module
-
 FP_SRC = $(wildcard src/fp/fp*.c)
-FP_OBJECTS = $(patsubst %.c, %.o, $(FP_SRC))
-FP_DEPS = $(patsubst %.c, %.d, $(FP_SRC))
-
-src/fp/%.d: src/fp/%.c $(NN_CONFIG) $(CFG_DEPS)
-	$(if $(filter $(wildcard src/fp/*.c), $<), @$(CC) $(LIB_CFLAGS) -MM $< -MF $@)
-
-src/fp/%.o: src/fp/%.c $(NN_CONFIG) $(CFG_DEPS)
-	$(if $(filter $(wildcard src/fp/*.c), $<), $(CC) $(LIB_CFLAGS) -c $< -o $@)
-
-
-LIBARITH_OBJECTS = $(FP_OBJECTS) $(NN_OBJECTS) $(RAND_OBJECTS) $(UTILS_ARITH_OBJECTS)
-$(LIBARITH): $(LIBARITH_OBJECTS)
-	$(AR) $(AR_FLAGS) $@ $^
-	$(RANLIB) $(RANLIB_FLAGS) $@
-
-# Compile dynamic libraries if the user asked to
-ifeq ($(WITH_DYNAMIC_LIBS),1)
-$(LIBARITH_DYN): $(LIBARITH_OBJECTS)
-	$(CC) $(LIB_CFLAGS) $(LIB_DYN_LDFLAGS) $^ -o $@
-endif
 
 # curve module
-
 CURVES_SRC = $(wildcard src/curves/*.c)
-CURVES_OBJECTS = $(patsubst %.c, %.o, $(CURVES_SRC))
-CURVES_DEPS = $(patsubst %.c, %.d, $(CURVES_SRC))
-
-src/curves/%.d: src/curves/%.c $(NN_CONFIG) $(CFG_DEPS)
-	$(if $(filter $(wildcard src/curves/*.c), $<), @$(CC) $(LIB_CFLAGS) -MM $< -MF $@)
-
-src/curves/%.o: src/curves/%.c $(NN_CONFIG) $(CFG_DEPS)
-	$(if $(filter $(wildcard src/curves/*.c), $<), $(CC) $(LIB_CFLAGS) -c $< -o $@)
-
-
-LIBEC_OBJECTS = $(LIBARITH_OBJECTS) $(CURVES_OBJECTS) $(UTILS_EC_OBJECTS)
-$(LIBEC): $(LIBEC_OBJECTS)
-	$(AR) $(AR_FLAGS) $@ $^
-	$(RANLIB) $(RANLIB_FLAGS) $@
-
-# Compile dynamic libraries if the user asked to
-ifeq ($(WITH_DYNAMIC_LIBS),1)
-$(LIBEC_DYN): $(LIBEC_OBJECTS)
-	$(CC) $(LIB_CFLAGS) $(LIB_DYN_LDFLAGS) $^ -o $@
-endif
 
 # Hash module
-
 HASH_SRC = $(wildcard src/hash/sha*.c) src/hash/hash_algs.c src/hash/sm3.c src/hash/streebog.c src/hash/ripemd160.c src/hash/hmac.c
-HASH_OBJECTS = $(patsubst %.c, %.o, $(HASH_SRC))
-HASH_DEPS = $(patsubst %.c, %.d, $(HASH_SRC))
-
-src/hash/%.d: src/hash/%.c $(CFG_DEPS)
-	$(if $(filter $(wildcard src/hash/*.c), $<), @$(CC) $(LIB_CFLAGS) -MM $< -MF $@)
-
-src/hash/%.o: src/hash/%.c $(CFG_DEPS)
-	$(if $(filter $(wildcard src/hash/*.c), $<), $(CC) $(LIB_CFLAGS) -c $< -o $@)
-
 
 # Key/Signature/Verification/ECDH module
-
 SIG_SRC = $(wildcard src/sig/*dsa.c) src/sig/ecdsa_common.c src/sig/ecsdsa_common.c src/sig/sig_algs.c src/sig/sm2.c src/sig/decdsa.c
-SIG_OBJECTS = $(patsubst %.c, %.o, $(SIG_SRC))
-SIG_DEPS = $(patsubst %.c, %.d, $(SIG_SRC))
-
-src/sig/%.d: src/sig/%.c $(NN_CONFIG) $(CFG_DEPS)
-	$(if $(filter $(wildcard src/sig/*.c), $<), @$(CC) $(LIB_CFLAGS) -MM $< -MF $@)
-
-src/sig/%.o: src/sig/%.c $(NN_CONFIG) $(CFG_DEPS)
-	$(if $(filter $(wildcard src/sig/*.c), $<), $(CC) $(LIB_CFLAGS) -c $< -o $@)
-
 ECDH_SRC = $(wildcard src/ecdh/*.c)
-ECDH_OBJECTS = $(patsubst %.c, %.o, $(ECDH_SRC))
-ECDH_DEPS = $(patsubst %.c, %.d, $(ECDH_SRC))
-
-src/ecdh/%.d: src/ecdh/%.c $(NN_CONFIG) $(CFG_DEPS)
-	$(if $(filter $(wildcard src/ecdh/*.c), $<), @$(CC) $(LIB_CFLAGS) -MM $< -MF $@)
-
-src/ecdh/%.o: src/ecdh/%.c $(NN_CONFIG) $(CFG_DEPS)
-	$(if $(filter $(wildcard src/ecdh/*.c), $<), $(CC) $(LIB_CFLAGS) -c $< -o $@)
-
-
 KEY_SRC = src/sig/ec_key.c
-KEY_OBJECTS = $(patsubst %.c, %.o, $(KEY_SRC))
-KEY_DEPS = $(patsubst %.c, %.d, $(KEY_SRC))
 
-$(KEY_DEPS): $(KEY_SRC) $(NN_CONFIG) $(CFG_DEPS)
-	$(if $(filter $(wildcard src/sig/*.c), $<), @$(CC) $(LIB_CFLAGS) -MM $< -MF $@)
-
-$(KEY_OBJECTS): $(KEY_SRC) $(NN_CONFIG) $(CFG_DEPS)
-	$(if $(filter $(wildcard src/sig/*.c), $<), $(CC) $(LIB_CFLAGS) -c $< -o $@)
-
-
-LIBSIGN_OBJECTS = $(LIBEC_OBJECTS) $(HASH_OBJECTS) $(SIG_OBJECTS) $(KEY_OBJECTS) $(UTILS_SIGN_OBJECTS) $(ECDH_OBJECTS)
-$(LIBSIGN): $(LIBSIGN_OBJECTS)
-	$(AR) $(AR_FLAGS) $@ $^
-	$(RANLIB) $(RANLIB_FLAGS) $@
-
-# Compile dynamic libraries if the user asked to
-ifeq ($(WITH_DYNAMIC_LIBS),1)
-$(LIBSIGN_DYN): $(LIBSIGN_OBJECTS)
-	$(CC) $(LIB_CFLAGS) $(LIB_DYN_LDFLAGS) $^ -o $@
-endif
-
-# Test elements (objects and binaries)
-
+# Test elements
 TESTS_OBJECTS_CORE_SRC = src/tests/ec_self_tests_core.c
-TESTS_OBJECTS_CORE = $(patsubst %.c, %.o, $(TESTS_OBJECTS_CORE_SRC))
-TESTS_OBJECTS_CORE_DEPS = $(patsubst %.c, %.d, $(TESTS_OBJECTS_CORE_SRC))
 TESTS_OBJECTS_SELF_SRC = src/tests/ec_self_tests.c
-TESTS_OBJECTS_SELF = $(patsubst %.c, %.o, $(TESTS_OBJECTS_SELF_SRC))
-TESTS_OBJECTS_SELF_DEPS = $(patsubst %.c, %.d, $(TESTS_OBJECTS_SELF_SRC))
 TESTS_OBJECTS_UTILS_SRC = src/tests/ec_utils.c
-TESTS_OBJECTS_UTILS = $(patsubst %.c, %.o, $(TESTS_OBJECTS_UTILS_SRC))
-TESTS_OBJECTS_UTILS_DEPS = $(patsubst %.c, %.d, $(TESTS_OBJECTS_UTILS_SRC))
-
-$(TESTS_OBJECTS_CORE_DEPS): $(TESTS_OBJECTS_CORE_SRC) $(CFG_DEPS)
-	$(if $(filter $(wildcard src/tests/*.c), $<), @$(CC) $(LIB_CFLAGS) -MM $< -MF $@)
-
-$(TESTS_OBJECTS_CORE): $(TESTS_OBJECTS_CORE_SRC) $(CFG_DEPS)
-	$(if $(filter $(wildcard src/tests/*.c), $<), $(CC) $(LIB_CFLAGS) -c $< -o $@)
-
-src/tests/%.d:  src/tests/%.c $(CFG_DEPS)
-	$(if $(filter src/tests/ec_utils.c, $<), $(CC) $(LIB_CFLAGS) -MM $< -MF $@)
-	$(if $(filter-out src/tests/ec_utils.c, $<), $(CC) $(LIB_CFLAGS) -MM $< -MF $@)
-
-$(BUILD_DIR)/ec_self_tests: $(TESTS_OBJECTS_CORE) $(TESTS_OBJECTS_SELF_SRC) $(EXT_DEPS_OBJECTS) $(LIBSIGN)
-	$(CC) $(BIN_CFLAGS) $(BIN_LDFLAGS) $^ -o $@
-
-$(BUILD_DIR)/ec_utils: $(TESTS_OBJECTS_CORE) $(TESTS_OBJECTS_UTILS_SRC) $(EXT_DEPS_OBJECTS) $(LIBSIGN)
-	$(CC) $(BIN_CFLAGS) $(BIN_LDFLAGS) -DWITH_STDLIB  $^ -o $@
-
-# If the user asked for dynamic libraries, compile versions of our binaries against them
-ifeq ($(WITH_DYNAMIC_LIBS),1)
-$(BUILD_DIR)/ec_self_tests_dyn: $(TESTS_OBJECTS_CORE) $(TESTS_OBJECTS_SELF_SRC) $(EXT_DEPS_OBJECTS)
-	$(CC) $(BIN_CFLAGS) $(BIN_LDFLAGS) -L$(BUILD_DIR) $^ -lsign -o $@
-
-$(BUILD_DIR)/ec_utils_dyn: $(TESTS_OBJECTS_CORE) $(TESTS_OBJECTS_UTILS_SRC) $(EXT_DEPS_OBJECTS)
-	$(CC) $(BIN_CFLAGS) $(BIN_LDFLAGS) -L$(BUILD_DIR) -DWITH_STDLIB  $^ -lsign -o $@
-endif
 
 
-DEPENDS = $(EXT_DEPS_DEPS) $(UTILS_ARITH_DEPS) $(UTILS_EC_DEPS) $(UTILS_SIGN_DEPS) $(NN_DEPS) $(FP_DEPS) $(CURVES_DEPS) \
-	  $(HASH_DEPS) $(SIG_DEPS) $(KEY_DEPS) $(TESTS_OBJECTS_CORE_DEPS) $(TESTS_OBJECTS_SELF_DEPS) $(TESTS_OBJECTS_UTILS_DEPS)
-depend: $(DEPENDS)
 
-.PHONY: all depend clean 16 32 64 debug debug16 debug32 debug64 force_arch32 force_arch64
+# --- Static Libraries ---
+
+LIBARITH_SRC = $(FP_SRC) $(NN_SRC) $(RAND_SRC) $(UTILS_ARITH_SRC)
+LIBARITH_OBJECTS = $(patsubst %,$(OBJ_DIR)/%.o,$(basename $(LIBARITH_SRC)))
+$(LIBARITH): $(LIBARITH_OBJECTS)
+	@$(CROSS_COMPILE)$(AR) $(AR_FLAGS) $@ $^
+	@$(CROSS_COMPILE)$(RANLIB) $(RANLIB_FLAGS) $@
+
+LIBEC_SRC = $(LIBARITH_SRC) $(CURVES_SRC) $(UTILS_EC_SRC)
+LIBEC_OBJECTS = $(patsubst %,$(OBJ_DIR)/%.o,$(basename $(LIBEC_SRC)))
+$(LIBEC): $(LIBEC_OBJECTS)
+	@$(CROSS_COMPILE)$(AR) $(AR_FLAGS) $@ $^
+	@$(CROSS_COMPILE)$(RANLIB) $(RANLIB_FLAGS) $@
+
+LIBSIGN_SRC = $(LIBEC_SRC) $(HASH_SRC) $(SIG_SRC) $(KEY_SRC) $(UTILS_SIGN_SRC) $(ECDH_SRC)
+LIBSIGN_OBJECTS = $(patsubst %,$(OBJ_DIR)/%.o,$(basename $(LIBSIGN_SRC)))
+$(LIBSIGN): $(LIBSIGN_OBJECTS)
+	@$(CROSS_COMPILE)$(AR) $(AR_FLAGS) $@ $^
+	@$(CROSS_COMPILE)$(RANLIB) $(RANLIB_FLAGS) $@
+
+
+
+# --- Dynamic Libraries ---
+
+$(LIBARITH_DYN): $(LIBARITH_OBJECTS)
+	@$(CROSS_COMPILE)$(CC) $(LIB_CFLAGS) $(LIB_DYN_LDFLAGS) $^ -o $@
+
+$(LIBEC_DYN): $(LIBEC_OBJECTS)
+	@$(CROSS_COMPILE)$(CC) $(LIB_CFLAGS) $(LIB_DYN_LDFLAGS) $^ -o $@
+
+$(LIBSIGN_DYN): $(LIBSIGN_OBJECTS)
+	@$(CROSS_COMPILE)$(CC) $(LIB_CFLAGS) $(LIB_DYN_LDFLAGS) $^ -o $@
+
+
+
+# --- Executables (Static linkage with libsign object files) ---
+
+EC_SELF_TESTS_SRC = $(TESTS_OBJECTS_CORE_SRC) $(TESTS_OBJECTS_SELF_SRC) $(EXT_DEPS_SRC)
+EC_SELF_TESTS_OBJECTS = $(patsubst %,$(OBJ_DIR)/%.o,$(basename $(EC_SELF_TESTS_SRC)))
+$(BUILD_DIR)/ec_self_tests: $(EC_SELF_TESTS_OBJECTS) $(LIBSIGN_OBJECTS)
+	@$(CROSS_COMPILE)$(CC) $(BIN_CFLAGS) $(BIN_LDFLAGS) $^ -o $@
+
+EC_UTILS_SRC = $(TESTS_OBJECTS_CORE_SRC) $(TESTS_OBJECTS_UTILS_SRC) $(EXT_DEPS_SRC)
+EC_UTILS_OBJECTS = $(patsubst %,$(OBJ_DIR)/%.o,$(basename $(EC_UTILS_SRC)))
+$(BUILD_DIR)/ec_utils: $(EC_UTILS_SRC) $(LIBSIGN_OBJECTS)
+	@$(CROSS_COMPILE)$(CC) $(BIN_CFLAGS) $(BIN_LDFLAGS) -DWITH_STDLIB  $^ -o $@
+
+
+
+# --- Excutables (Dynamic linkage with libsign shared library) ---
+
+$(BUILD_DIR)/ec_self_tests_dyn: $(EC_SELF_TESTS_OBJECTS)
+	@$(CROSS_COMPILE)$(CC) $(BIN_CFLAGS) $(BIN_LDFLAGS) -L$(BUILD_DIR) $^ -lsign -o $@
+
+$(BUILD_DIR)/ec_utils_dyn: $(EC_UTILS_OBJECTS)
+	@$(CROSS_COMPILE)$(CC) $(BIN_CFLAGS) $(BIN_LDFLAGS) -L$(BUILD_DIR) -DWITH_STDLIB  $^ -lsign -o $@
+
+
+
+.PHONY: all clean 16 32 64 debug debug16 debug32 debug64 force_arch32 force_arch64
+
+# All source files, used to construct general rules
+SRC += $(EXT_DEPS_SRC) $(UTILS_ARITH_SRC) $(UTILS_EC_SRC) $(UTILS_SIGN_SRC)
+SRC += $(NN_SRC) $(FP_SRC) $(CURVES_SRC) $(HASH_SRC) $(SIG_SRC) $(ECDH_SRC)
+SRC += $(KEY_SRC) $(TESTS_OBJECTS_CORE_SRC) $(TESTS_OBJECTS_SELF_SRC)
+SRC += $(TESTS_OBJECTS_UTILS_SRC)
+
+# All object files
+OBJS = $(patsubst %,$(OBJ_DIR)/%.o,$(basename $(SRC)))
+
+# General dependency rule between .o and .d files
+DEPS = $(OBJS:.o=.d)
+
+# General rule for creating .o (and .d) file from .c
+$(OBJ_DIR)/%.o: %.c
+	@$(CROSS_COMPILE)$(CC) -c $(LIB_CFLAGS) -MMD -MP -o $@ $<
+
+# Populate the directory structure to contain the .o and .d files, if necessary
+$(shell mkdir -p $(dir $(OBJS)) >/dev/null)
+$(shell mkdir -p $(BUILD_DIR) >/dev/null)
+
+# Make object files depend on all makefiles used - this forces a rebuild if any
+# of the makefiles are changed
+$(OBJS) : $(MAKEFILES)
+
+# Dep files are makefiles that keep track of which header files are used by the
+# c source code. Include them to allow them to work correctly.
+-include $(DEPS)

--- a/README.md
+++ b/README.md
@@ -712,9 +712,9 @@ implementation of the gcc and clang stack protection option, usually expecting t
 
 Compiling for Cortex-M targets should be straightforward using the arm-gcc none-eabi (for bare metal) cross-compiler as
 well as the specific Cortex-M target platform SDK. In order to compile the core libsign.a static library, the only thing to do is to execute
-the makefile command by overloading `CC`and the `CFLAGS`:
+the makefile command by overloading `CROSS_COMPILE`, `CC` and the `CFLAGS`:
 <pre>
-	$ CC=arm-none-eabi-gcc CFLAGS="$(TARGET_OPTS) -W -Wextra -Wall -Wunreachable-code \
+	$ CROSS_COMPILE=arm-none-eabi- CC=gcc CFLAGS="$(TARGET_OPTS) -W -Wextra -Wall -Wunreachable-code \
 	-pedantic -fno-builtin -std=c99 -Os \
 	-ffreestanding -fno-builtin -nostdlib -DWORDSIZE=64" \
 	make build/libsign.a
@@ -730,7 +730,7 @@ a firmware suitable for the target (ST for STM32, NXP for LPC, Atmel for SAM, ..
 If the external dependencies have been implemented by the user, it is also possible to build a self-tests binary by adding the
 GNU ld linker script specific to the target platform (`linker_script.ld` in the example below):
 <pre>
-	$ CC=arm-none-eabi-gcc CFLAGS="$(TARGET_OPTS) -W -Wextra -Wall -Wunreachable-code \
+	$ CROSS_COMPILE=arm-none-eabi- CFLAGS="$(TARGET_OPTS) -W -Wextra -Wall -Wunreachable-code \
 	-pedantic -fno-builtin -std=c99 -Os \
 	-ffreestanding -fno-builtin -nostdlib -DWORDSIZE=64" \
 	LDFLAGS="-T linker_script.ld" \

--- a/common.mk
+++ b/common.mk
@@ -1,9 +1,9 @@
 # Detect mingw, since some versions throw a warning with the -fPIC option
 # (which would be caught as an error in our case with -Werror)
 # The ELF PIE related hardening flags are also non sense for Windows
-MINGW := $(shell $(CC) -dumpmachine 2>&1 | grep -v mingw)
+MINGW := $(shell $(CROSS_COMPILE)$(CC) -dumpmachine 2>&1 | grep -v mingw)
 # Detect Mac OS compilers: these usually don't like ELF pie related flags ...
-APPLE := $(shell $(CC) -dumpmachine 2>&1 | grep -v apple)
+APPLE := $(shell $(CROSS_COMPILE)$(CC) -dumpmachine 2>&1 | grep -v apple)
 ifneq ($(MINGW),)
 FPIC_CFLAG=-fPIC
 ifneq ($(APPLE),)
@@ -32,7 +32,7 @@ FORTIFY_FLAGS=-D_FORTIFY_SOURCE=2
 #   -Wno-covered-switch-default
 #   -Wno-used-but-marked-unused
 #
-CLANG :=  $(shell $(CC) -v 2>&1 | grep clang)
+CLANG :=  $(shell $(CROSS_COMPILE)$(CC) -v 2>&1 | grep clang)
 ifneq ($(CLANG),)
 WARNING_CFLAGS = -Weverything -Werror \
 		 -Wno-reserved-id-macro -Wno-padded \
@@ -43,7 +43,7 @@ ifeq ($(PEDANTIC),1)
 WARNING_CFLAGS += -Werror -Walloca -Wcast-qual -Wconversion -Wformat=2 -Wformat-security -Wnull-dereference -Wstack-protector -Wvla -Warray-bounds -Warray-bounds-pointer-arithmetic -Wassign-enum -Wbad-function-cast -Wconditional-uninitialized -Wconversion -Wfloat-equal -Wformat-type-confusion -Widiomatic-parentheses -Wimplicit-fallthrough -Wloop-analysis -Wpointer-arith -Wshift-sign-overflow -Wshorten-64-to-32 -Wtautological-constant-in-range-compare -Wunreachable-code-aggressive -Wthread-safety -Wthread-safety-beta -Wcomma
 endif
 # Clang version >= 13? Adapt
-CLANG_VERSION_GTE_13 := $(shell echo `$(CC) -dumpversion | cut -f1-2 -d.` \>= 13.0 | sed -e 's/\./*100+/g' | bc)
+CLANG_VERSION_GTE_13 := $(shell echo `$(CROSS_COMPILE)$(CC) -dumpversion | cut -f1-2 -d.` \>= 13.0 | sed -e 's/\./*100+/g' | bc)
   ifeq ($(CLANG_VERSION_GTE_13), 1)
   # We have to do this because the '_' prefix seems now reserved to builtins
   WARNING_CFLAGS += -Wno-reserved-identifier
@@ -244,7 +244,7 @@ ifeq ($(USE_SANITIZERS),1)
 CFLAGS += -fsanitize=undefined -fsanitize=address -fsanitize=leak
   ifneq ($(CLANG),)
     # Clang version < 12 do not support unsigned-shift-base
-    CLANG_VERSION_GTE_12 := $(shell echo `$(CC) -dumpversion | cut -f1-2 -d.` \>= 12.0 | sed -e 's/\./*100+/g' | bc)
+    CLANG_VERSION_GTE_12 := $(shell echo `$(CROSS_COMPILE)$(CC) -dumpversion | cut -f1-2 -d.` \>= 12.0 | sed -e 's/\./*100+/g' | bc)
     ifeq ($(CLANG_VERSION_GTE_12), 1)
       CFLAGS += -fsanitize=integer -fno-sanitize=unsigned-integer-overflow -fno-sanitize=unsigned-shift-base
     endif
@@ -259,8 +259,8 @@ CFLAGS += -DUSE_ISO14888_3_ECRDSA
 endif
 
 # Do we have a C++ compiler instead of a C compiler?
-GPP := $(shell $(CC) -v 2>&1 | grep g++)
-CLANGPP := $(shell echo $(CC) | grep clang++)
+GPP := $(shell $(CROSS_COMPILE)$(CC) -v 2>&1 | grep g++)
+CLANGPP := $(shell echo $(CROSS_COMPILE)$(CC) | grep clang++)
 
 # g++ case
 ifneq ($(GPP),)


### PR DESCRIPTION
For your consideration.

I have a project that needs to compile for multiple targets (Windows, Linux, Embedded Cortex-M4) from a single source tree. With the current Makefile this is problematic because all the .o and .d files are compiled next to the relevant .c files in the src tree, which means that any time the target gets built *everything* has to recompile. I have added the ability, if desired, to set OBJ_DIR (as well as the existing BUILD_DIR variable) which will output the .o and .d files into a separate directory tree. This approach also enables consistent incremental builds when working across multiple targets.

In addition, I have added the ability to use the CROSS_COMPILE variable - a standard method for compiling to targets other than the host system - an approach often used with embedded systems. This variable can be left unset, if desired, and the prior behaviour requiring CC et al to be set manually will continue to operate as documented.

I noted some oddities with respect to dependency checking (for example, TESTS_OBJECTS_CORE_DEPS having a dependency on TESTS_OBJECTS_CORE_SRC (the .c file), rather than TESTS_OBJECTS_CORE (the .o file). This has now all been standardized, and generic dependency rules have been generated for .o and .d files with respect to their .c files.

The .o and .d compilation rules have also been unified into a single compilation rule. This should ensure that the .o and .d files stay in sync (no longer separate compilation steps), as well as improving build times a bit.

The makefile(s) have been added as a dependency to the object files - this ensures that everything rebuilds as expected if there are ever any makefile changes.

The .d dependency files are now included into the Makefile, rather than being stated explicitly as dependencies for specific targets. This has the added benefit of being less error-prone with respect to Makefile maintenance.

TLDR:
- Add support for building .o and .d files to different directory.
- Clean up dependency handling.
- Add support for the use of the CROSS_COMPILE variable.
- Remove unused/undefined RAND_OBJECTS from libarith.
- Generalize dependency handling.
- Use single command to compile .c code into .o and .d files.
- Replace explicit dependencies on source code & dependency files.