### PR TITLE
fix compilation error on VERBOSE_INNER_VALUES specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -867,6 +867,7 @@ the **less efficient but more compatible** `-fstack-protector-all`.
 In addition to compilation flags, it is also possible to overload the library **word sizes** as well as **debug**
 modes through Makefile targets:
 * `make debug` will compile a debug version of the library and binaries, with debugging symbols.
+Setting the environment variable `VERBOSE_INNER_VALUES=1` will print out more values.
 * `make 16`, `make 32` and `make 64` will respectively compile the library with 16, 32 and 64 bits word sizes. `make debug16`,
 `make debug32` and `make debug64` will compile the debug versions of these.
 * `make force_arch32` and `make force_arch64` will force 32-bit and 64-bit architectures compilation (`-m32` and `-m64`

--- a/common.mk
+++ b/common.mk
@@ -84,6 +84,10 @@ RANLIB_FLAGS ?=
 # Our debug flags
 DEBUG_CFLAGS = -DDEBUG -O -g
 
+ifeq ($(VERBOSE_INNER_VALUES),1)
+DEBUG_CFLAGS += -DVERBOSE_INNER_VALUES
+endif
+
 # Default all and clean target that will be expanded
 # later in the Makefile
 all:

--- a/src/sig/ecdsa_common.c
+++ b/src/sig/ecdsa_common.c
@@ -768,7 +768,7 @@ int __ecdsa_verify_finalize(struct ec_verify_context *ctx,
 	 */
 	ret = nn_init_from_buf(&e, hash, hsize); EG(ret, err);
 	ret = local_memset(hash, 0, hsize); EG(ret, err);
-	dbg_nn_print("h initial import as nn", &tmp);
+	dbg_nn_print("h initial import as nn", &e);
 	if (rshift) {
 		ret = nn_rshift_fixedlen(&e, &e, rshift); EG(ret, err);
 	}

--- a/src/sig/eddsa.c
+++ b/src/sig/eddsa.c
@@ -1640,7 +1640,7 @@ int _eddsa_sign(u8 *sig, u8 siglen, const ec_key_pair *key_pair,
 	dbg_nn_print("q", &(priv_key->params->ec_gen_order));
 	dbg_priv_key_print("x", priv_key);
 	dbg_ec_point_print("G", &(priv_key->params->ec_gen));
-	dbg_pub_key_print("Y", &(pub_key));
+	dbg_pub_key_print("Y", pub_key);
 
 	/* Check provided signature length */
 	MUST_HAVE((siglen == EDDSA_SIGLEN(hsize)) && (siglen == (r_len + s_len)), ret, err);


### PR DESCRIPTION
Also add VERBOSE_INNER_VALUES to CFLAGS when DEBUG is enabled,
I think this is a sensible default.